### PR TITLE
Drop gleam_community_maths dependancy

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -18,5 +18,4 @@ links = [
 
 [dependencies]
 gleam_stdlib = ">= 0.58.0 and < 2.0.0"
-gleam_community_maths = { git = "https://github.com/gleam-community/maths", ref = "e5d491efa4e5752e109a6eaaa9e8f0d54945883a" }
 gleam_community_colour = ">= 2.0.0 and < 3.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,11 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_community_colour", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "FDD6AC62C6EC8506C005949A4FCEF032038191D5EAAEC3C9A203CD53AE956ACA" },
-  { name = "gleam_community_maths", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], source = "git", repo = "https://github.com/gleam-community/maths", commit = "e5d491efa4e5752e109a6eaaa9e8f0d54945883a" },
-  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
-  { name = "gleam_stdlib", version = "0.58.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "091F2D2C4A3A4E2047986C47E2C2C9D728A4E068ABB31FDA17B0D347E6248467" },
-  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleam_community_colour", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "E34DD2C896AC3792151EDA939DA435FF3B69922F33415ED3C4406C932FBE9634" },
+  { name = "gleam_json", version = "3.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "874FA3C3BB6E22DD2BB111966BD40B3759E9094E05257899A7C08F5DE77EC049" },
+  { name = "gleam_stdlib", version = "0.63.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5E216C7D5E8BE22359C9D7DAA2CFBD66039BC12565542F34CD033C5BB57071ED" },
 ]
 
 [requirements]
 gleam_community_colour = { version = ">= 2.0.0 and < 3.0.0" }
-gleam_community_maths = { git = "https://github.com/gleam-community/maths", ref = "e5d491efa4e5752e109a6eaaa9e8f0d54945883a" }
 gleam_stdlib = { version = ">= 0.58.0 and < 2.0.0" }

--- a/src/numbers_ffi.mjs
+++ b/src/numbers_ffi.mjs
@@ -1,0 +1,3 @@
+export function pi() {
+	return Math.PI;
+}

--- a/src/paint.gleam
+++ b/src/paint.gleam
@@ -3,7 +3,6 @@
 
 import gleam/result
 import gleam_community/colour
-import gleam_community/maths.{pi}
 import paint/internal/types as internal_implementation
 
 /// A 2D picture. This is the type which this entire library revolves around.
@@ -176,4 +175,11 @@ pub fn combine(pictures: List(Picture)) -> Picture {
 /// ```
 pub fn just(picture: Picture) -> fn(a) -> Picture {
   fn(_config) { picture }
+}
+
+// Internal utility function to get Pi π 
+@external(erlang, "math", "pi")
+@external(javascript, "./numbers_ffi.mjs", "pi")
+fn pi() -> Float {
+  3.1415926
 }


### PR DESCRIPTION
only using one function (pi) from this library, and I think it's a good idea for portability to just implement it ourselves, especially considering how easily it can be done with FFI. I even have a pure-Gleam fallback value :D